### PR TITLE
Job locked licenses

### DIFF
--- a/client/nui.lua
+++ b/client/nui.lua
@@ -62,6 +62,7 @@ function NUI:SetupItems()
     }
 
     local PlayerLicenses = QBCore.Functions.GetPlayerData().metadata["licences"]
+    local PlayerJobLicenses = QBCore.Functions.GetPlayerData().job.name
 
     for key = 1, #Config.items, 1 do
         for k, value in pairs(PlayerLicenses) do
@@ -72,6 +73,13 @@ function NUI:SetupItems()
                     id = key
                 }
             end
+        end
+        if (Config.items[key].job == PlayerJobLicenses) then
+            items[#items + 1] = {
+                name = Config.items[key].label,
+                price = Config.items[key].price,
+                id = key
+        }
         end
     end
 

--- a/config.lua
+++ b/config.lua
@@ -49,20 +49,21 @@ Config.jobs = {
 
 -- Items for purchase
 Config.items = {{
-    item = "id_card",
-    meta = 'id',
-    label = "ID Card",
-    price = 100
+    item = "id_card", -- Name of ID Document
+    meta = 'id', -- Metadata to check if eligible for ID document
+    label = "ID Card", -- Label to show in the menu for the ID document
+    price = 100 -- Price of the ID document
 }, {
-    item = "driver_license",
-    label = "Driver License",
-    meta = 'driver',
-    price = 100
+    item = "driver_license", -- Name of ID Document
+    label = "Driver License",-- Label to show in the menu for the ID document
+    meta = 'driver',  -- Metadata to check if eligible for ID document
+    price = 100 -- Price of the ID document
 }, {
-    item = "weaponlicense",
-    label = "Weapon License",
-    meta = 'weapon',
-    price = 100
+    item = "weaponlicense", -- Name of ID Document
+    label = "Weapon License", -- Label to show in the menu for the ID document
+    meta = 'weapon',  -- Metadata to check if eligible for ID document
+    --job = 'ammunation' -- Job check this will show the ID document to anyone with this job, Make sure to comment out "meta" if wanting to use the job check
+    price = 100 -- Price of the ID document
 }}
 
 -- Items shown in the information tab


### PR DESCRIPTION
Add the ability for Cityhall to check for job roles for licenses to be displayed

Also added comments into the config just for clarification on each part and added commented out job role for weapon license as an example